### PR TITLE
[FeatureMade] 20220224 피쳐타겟분리, train,test분리, None이 입력 안되는 이슈 해결

### DIFF
--- a/functions/__init__.py
+++ b/functions/__init__.py
@@ -28,6 +28,11 @@ from functions.processing import (
     set_column
 )
 
+from functions.preprocessing import (
+    set_feature_target_split,
+    set_train_test_split,
+)
+
 __all__ = [
     "create_upload_file", 
 
@@ -54,4 +59,7 @@ __all__ = [
     "set_merge",
     "set_concat",
     "set_column",
+
+    "set_feature_target_split",
+    "set_train_test_split",
 ]

--- a/functions/eda.py
+++ b/functions/eda.py
@@ -104,6 +104,11 @@ async def get_corr(
     (str): JSON
     ```
     """
+    method  = "pearson" if method  == "" else method
+    req_min = 1         if req_min == "" else req_min
+    col1    = None      if col1    == "" else col1
+    col2    = None      if col2    == "" else col2
+
     if not method in ["pearson", "kendall", "spearman"]:
         return 'method should be in ["pearson", "kendall", "spearman"]'
     
@@ -185,6 +190,13 @@ async def get_describe(
     (str): JSON
     ```
     """
+    percentiles = None if percentiles == "" else percentiles
+    num         = 0    if num         == "" else num
+    obj         = 0    if obj         == "" else obj
+    cat         = 0    if cat         == "" else cat
+    date        = 0    if date        == "" else date
+    date2num    = ""   if date2num    == "" else date2num
+
 
     if percentiles is not None:
         try:
@@ -308,6 +320,11 @@ async def get_col_condition(
     str: JSON
     ```
     """
+    cond1  = None if cond1  == "" else cond1
+    value1 = None if value1 == "" else value1
+    cond2  = None if cond2  == "" else cond2
+    value2 = None if value2 == "" else value2
+
     df = pd.read_json(await item.json())
     
     if cond1 not in ["eq", "gr", "gr_eq", "le", "le_eq"]:
@@ -399,6 +416,13 @@ async def get_loc(
     str: JSON
     ```
     """
+    idx       = None if idx      == "" else idx
+    idx_from  = None if idx_from == "" else idx_from
+    idx_to    = None if idx_to   == "" else idx_to
+    cols      = None if cols     == "" else cols
+    col_from  = None if col_from == "" else col_from
+    col_to    = None if col_to   == "" else col_to
+
     df = pd.read_json(await item.json())
 
     if str(df.index.dtype) == "int64":
@@ -488,6 +512,13 @@ async def get_iloc(
     str: JSON
     ```
     """
+    idx       = None if idx      == "" else idx
+    idx_from  = None if idx_from == "" else idx_from
+    idx_to    = None if idx_to   == "" else idx_to
+    cols      = None if cols     == "" else cols
+    col_from  = None if col_from == "" else col_from
+    col_to    = None if col_to   == "" else col_to
+    
     df = pd.read_json(await item.json())
 
     if idx is None: 

--- a/functions/preprocessing.py
+++ b/functions/preprocessing.py
@@ -55,7 +55,7 @@ async def set_train_test_split(
     train_size  : Optional[str] = Query(None,   max_length=50),
     random_state: Optional[str] = Query(None,   max_length=50),
     shuffle     : Optional[str] = Query("true", max_length=50),
-    stratify    : Optional[str] = Query("y",   max_length=50),
+    stratify    : Optional[str] = Query(None,   max_length=50),
 ) -> str:
     """
     ```python
@@ -63,16 +63,17 @@ async def set_train_test_split(
     
     # 입력 item은 X 와 y 키에 각각 데이터 프레임이 들어있어야 함.
     # test_size와 train_size는 둘 중 하나만 입력 가능.
+    # stratify는 None 또는 'y'만 가능
     ```
     Args:
     ```
     item         (Request, required): JSON, {"X":X_dataframe, "y":y_dataframe}
     *,
-    test_size    (str,     optional): Default = None, 0~1 사이의 소수. 테스트 셋의 비율
-    train_size   (str,     optional): Default = None, 0~1 사이의 소수. 트레인 셋의 비율
-    random_state (str,     optional): Default = None, 아무 정수. 랜덤 시드
-    shuffle      (str,     optional): Default = True, 셔플 여부. true 셔플함, false, 셔플 안함
-    stratify     (str,     optional): Default = "y", 타겟을 지정. 보통 건드릴 일 X
+    test_size    (str,     optional): Default = None,   0~1 사이의 소수. 테스트 셋의 비율
+    train_size   (str,     optional): Default = None,   0~1 사이의 소수. 트레인 셋의 비율
+    random_state (str,     optional): Default = None,   아무 정수. 랜덤 시드
+    shuffle      (str,     optional): Default = "true", 셔플 여부. true 셔플함, false, 셔플 안함
+    stratify     (str,     optional): Default = None,   타겟을 지정. train, valid split할 때 y를 입력하면 됨.
     ```
     Returns:
     ```
@@ -89,7 +90,7 @@ async def set_train_test_split(
     train_size   = None   if train_size   == "" else train_size
     random_state = None   if random_state == "" else random_state
     shuffle      = "true" if shuffle      == "" else shuffle
-    stratify     = "y"    if stratify     == "" else stratify
+    stratify     = None   if stratify     == "" else stratify
 
     dfs = await item.json()
     X = pd.read_json(dfs["X"])
@@ -145,8 +146,6 @@ async def set_train_test_split(
     # shuffle  = False,
     # stratify = None
 
-    # how to return?
-    # 1안 
     return json.dumps( {
         "X_train": X_train.to_json(orient="records"),
         "X_test" : X_test.to_json(orient="records"),

--- a/functions/preprocessing.py
+++ b/functions/preprocessing.py
@@ -55,7 +55,7 @@ async def set_train_test_split(
     train_size  : Optional[str] = Query(None,   max_length=50),
     random_state: Optional[str] = Query(None,   max_length=50),
     shuffle     : Optional[str] = Query("true", max_length=50),
-    # stratify    : Optional[str] = Query(None,   max_length=50),
+    stratify    : Optional[str] = Query("y",   max_length=50),
 ) -> str:
     """
     ```python
@@ -72,7 +72,7 @@ async def set_train_test_split(
     train_size   (str,     optional): Default = None, 0~1 사이의 소수. 트레인 셋의 비율
     random_state (str,     optional): Default = None, 아무 정수. 랜덤 시드
     shuffle      (str,     optional): Default = True, 셔플 여부. true 셔플함, false, 셔플 안함
-    stratify     (str,     optional): Default = None, 
+    stratify     (str,     optional): Default = "y", 타겟을 지정. 보통 건드릴 일 X
     ```
     Returns:
     ```
@@ -89,7 +89,7 @@ async def set_train_test_split(
     train_size   = None   if train_size   == "" else train_size
     random_state = None   if random_state == "" else random_state
     shuffle      = "true" if shuffle      == "" else shuffle
-    # stratify     = None   if stratify     == "" else stratify
+    stratify     = "y"    if stratify     == "" else stratify
 
     dfs = await item.json()
     X = pd.read_json(dfs["X"])
@@ -127,7 +127,10 @@ async def set_train_test_split(
         # If not None, data is split in a stratified fashion, using this as
         # the class labels.
         # Read more in the :ref:`User Guide <stratification>`.
-
+    if stratify.lower() == "y":
+        stratify = y
+    else:
+        stratify = None
 
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, # *arrays
@@ -135,7 +138,7 @@ async def set_train_test_split(
         train_size   = train_size,
         random_state = random_state,
         shuffle      = shuffle,
-        # stratify     = stratify,
+        stratify     = stratify,
     )
 
     # 시계열 기준일 경우 

--- a/functions/preprocessing.py
+++ b/functions/preprocessing.py
@@ -4,14 +4,34 @@ import json
 import numpy as np
 import pandas as pd
 from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import OneHotEncoder, LabelEncoder, OrdinalEncoder
+from category_encoders import OneHotEncoder, OrdinalEncoder, TargetEncoder
 # import modin.pandas as pd
+
+def boolean(x):
+    if   x.lower() == "true" : return True
+    elif x.lower() == "false": return False
+
 
 async def set_feature_target_split(
     item : Request,
     cols : str
 ) -> str:
-    ...
+    """
+    ```python
+    # 타겟과 피쳐를 나누는 함수
+    target = pandas.DataFrame[cols]               # y
+    feature = pandas.DataFrame.drop(cols, axis=1) # X
+    ```
+    Args:
+    ```
+    item (Request, required): JSON, 입력 데이터 프레임(전처리 끝난 데이터 프레임)
+    cols (str,     required): 쉼표로 구분된 타겟 컬럼.(1개 이상)
+    ```
+    Returns:
+    ```
+    str: JSON, {"X":feature_df, "y":target_df}
+    ```
+    """
     df = pd.read_json(await item.json())
 
     dfcols = set(df.columns)
@@ -21,56 +41,216 @@ async def set_feature_target_split(
 
     y = df[cols]
     X = df.drop(cols, axis=1)
-    # how to return?
-    # 1안 
-    # return json.dumps( {
-    #     "X": X.to_json(orient="records"),
-    #     "y": y.to_json(orient="records"),
-    # } )
+
+    return json.dumps( {
+        "X": X.to_json(orient="records"),
+        "y": y.to_json(orient="records"),
+    } )
 
 
 async def set_train_test_split(
-    item    : Request,
-    col     : str,
+    item        : Request,
     *,
-    cols    : Optional[str] = Query(None, max_length=50), # for func
-    col_from: Optional[str] = Query(None, max_length=50), # for func
-    col_to  : Optional[str] = Query(None, max_length=50), # for func
-    func    : Optional[str] = Query(None, max_length=50),
-    cols_ops: Optional[str] = Query(None, max_length=50),
+    test_size   : Optional[str] = Query(None,   max_length=50),
+    train_size  : Optional[str] = Query(None,   max_length=50),
+    random_state: Optional[str] = Query(None,   max_length=50),
+    shuffle     : Optional[str] = Query("true", max_length=50),
+    # stratify    : Optional[str] = Query(None,   max_length=50),
 ) -> str:
+    """
+    ```python
+    X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(X, y)
+    
+    # 입력 item은 X 와 y 키에 각각 데이터 프레임이 들어있어야 함.
+    # test_size와 train_size는 둘 중 하나만 입력 가능.
+    ```
+    Args:
+    ```
+    item         (Request, required): JSON, {"X":X_dataframe, "y":y_dataframe}
+    *,
+    test_size    (str,     optional): Default = None, 0~1 사이의 소수. 테스트 셋의 비율
+    train_size   (str,     optional): Default = None, 0~1 사이의 소수. 트레인 셋의 비율
+    random_state (str,     optional): Default = None, 아무 정수. 랜덤 시드
+    shuffle      (str,     optional): Default = True, 셔플 여부. true 셔플함, false, 셔플 안함
+    stratify     (str,     optional): Default = None, 
+    ```
+    Returns:
+    ```
+    str: JSON, 
+    {
+        "X_train": X_train.to_json(orient="records"),
+        "X_test" : X_test .to_json(orient="records"),
+        "y_train": y_train.to_json(orient="records"),
+        "y_test" : y_test .to_json(orient="records"),
+    }
+    ```
+    """
+    test_size    = None   if test_size    == "" else test_size
+    train_size   = None   if train_size   == "" else train_size
+    random_state = None   if random_state == "" else random_state
+    shuffle      = "true" if shuffle      == "" else shuffle
+    # stratify     = None   if stratify     == "" else stratify
 
-    # X_train, X_test, y_train, y_test = train_test_split(
-    #     X, y
-    #     test_size=None,
-    #     train_size=None,
-    #     random_state=None,
-    #     shuffle=True,
-    #     stratify=None,
-    # )
+    dfs = await item.json()
+    X = pd.read_json(dfs["X"])
+    y = pd.read_json(dfs["y"])
+
+    ## test_size:    0 < test_size < 1 인 float
+    if test_size is not None:
+        try: 
+            test_size = float(test_size)
+            if test_size <= 0 or test_size >= 1:
+                return f'"test_size" should be float between 0, 1(not equal). current {test_size}'
+        except: return f'"test_size" should be float between 0, 1(not equal). current {test_size}'
+
+    ## train_size:   0 < train_size < 1 인 float
+    if train_size is not None:
+        if test_size is None:
+            try: 
+                train_size = float(train_size)
+                if train_size <= 0 or train_size >= 1:
+                    return f'"train_size" should be float between 0, 1(not equal). current {train_size}'
+            except: return f'"train_size" should be float between 0, 1(not equal). current {train_size}'
+        else:
+            return "Can only use train_size when test_size is None"
+
+    ## random_state: 랜덤 시드. int
+    try: random_state = int(random_state)
+    except: '"random_state" should be int.'
+
+    ## shuffle:      bool 셔플 여부
+    shuffle = boolean(shuffle)
+    if shuffle is None: return '"shuffle" should be bool, "true" or "false"'
+
+    ## stratify:     특정 값의 비율을 맞춰서 나눈다.
+        # stratify : array-like, default=None
+        # If not None, data is split in a stratified fashion, using this as
+        # the class labels.
+        # Read more in the :ref:`User Guide <stratification>`.
+
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, # *arrays
+        test_size    = test_size,
+        train_size   = train_size,
+        random_state = random_state,
+        shuffle      = shuffle,
+        # stratify     = stratify,
+    )
+
     # 시계열 기준일 경우 
     # shuffle  = False,
     # stratify = None
 
     # how to return?
     # 1안 
-    # return json.dumps( {
-    #     "X_train": X_train.to_json(orient="records"),
-    #     "X_test" : X_test.to_json(orient="records"),
-    #     "y_train": y_train.to_json(orient="records"),
-    #     "y_test" : y_test.to_json(orient="records"),
-    # } )
-    ...
+    return json.dumps( {
+        "X_train": X_train.to_json(orient="records"),
+        "X_test" : X_test.to_json(orient="records"),
+        "y_train": y_train.to_json(orient="records"),
+        "y_test" : y_test.to_json(orient="records"),
+    } )
 
 
-async def set_one_hot_encoder():
-    ...
+# async def set_one_hot_encoder(
+#     item          : Request,
+#     *,
+#     verbose       : Optional[str] = Query(0,       max_length=50),
+#     cols          : Optional[str] = Query(None,    max_length=50),
+#     drop_invariant: Optional[str] = Query(False,   max_length=50),
+#     return_df     : Optional[str] = Query(True,    max_length=50),
+#     handle_missing: Optional[str] = Query('value', max_length=50),
+#     handle_unknown: Optional[str] = Query('value', max_length=50),
+#     use_cat_names : Optional[str] = Query(False,   max_length=50),
+# ) -> str:
+#     dfs = [pd.read_json(i) for i in json.loads(await item.json())]
+
+#     onehot = OneHotEncoder(
+#         verbose=0, 
+#         cols=None, 
+#         drop_invariant=False, 
+#         return_df=True,
+#         handle_missing='value', 
+#         handle_unknown='value', 
+#         use_cat_names=False
+#     )
+#     df_encoded = []
+#     df_encoded.append(onehot.fit_transform(dfs[0]))
+#     for i in dfs[1:]:
+#         df_encoded.append(onehot.transform(i))
+    
+
+# async def set_ordinal_encoder(
+#     item          : Request,
+#     *,
+#     verbose       : Optional[str] = Query(0,       max_length=50),
+#     mapping       : Optional[str] = Query(None,    max_length=50),
+#     cols          : Optional[str] = Query(None,    max_length=50),
+#     drop_invariant: Optional[str] = Query(False,   max_length=50),
+#     return_df     : Optional[str] = Query(True,    max_length=50),
+#     handle_unknown: Optional[str] = Query('value', max_length=50),
+#     handle_missing: Optional[str] = Query('value', max_length=50),
+# ) -> str:
+#     """_summary_
+
+#     Args:
+#         item (Request): _description_
+#         *
+#         verbose (Optional[str], optional): _description_. Defaults to Query(0,       max_length=50).
+#         mapping (Optional[str], optional): _description_. Defaults to Query(None,    max_length=50).
+#         cols (Optional[str], optional): _description_. Defaults to Query(None,    max_length=50).
+#         drop_invariant (Optional[str], optional): _description_. Defaults to Query(False,   max_length=50).
+#         return_df (Optional[str], optional): _description_. Defaults to Query(True,    max_length=50).
+#         handle_unknown (Optional[str], optional): _description_. Defaults to Query('value', max_length=50).
+#         handle_missing (Optional[str], optional): _description_. Defaults to Query('value', max_length=50).
+
+#     Returns:
+#         str: _description_
+#     """
+#     dfs = [pd.read_json(i) for i in json.loads(await item.json())]
+
+#     ordinal = OrdinalEncoder(
+#         verbose=0, 
+#         mapping=None, 
+#         cols=None, 
+#         drop_invariant=False, 
+#         return_df=True,
+#         handle_unknown='value', 
+#         handle_missing='value'
+#     )
+
+#     df_encoded = []
+#     df_encoded.append(ordinal.fit_transform(dfs[0]))
+#     for i in dfs[1:]:
+#         df_encoded.append(ordinal.transform(i))
+    
 
 
-async def set_target_encoder():
-    ...
+# async def set_target_encoder(
+#     item            : Request,
+#     *,
+#     verbose         : Optional[str] = Query(0,       max_length=50),
+#     cols            : Optional[str] = Query(None,    max_length=50),
+#     drop_invariant  : Optional[str] = Query(False,   max_length=50),
+#     return_df       : Optional[str] = Query(True,    max_length=50),
+#     handle_missing  : Optional[str] = Query('value', max_length=50),
+#     handle_unknown  : Optional[str] = Query('value', max_length=50),
+#     min_samples_leaf: Optional[str] = Query(1,       max_length=50),
+#     smoothing       : Optional[str] = Query(1.0,     max_length=50),
+# ) -> str:
+#     dfs = [pd.read_json(i) for i in json.loads(await item.json())]
 
-
-async def set_ordinal_encoder():
-    ...
-
+#     target = TargetEncoder(
+#         verbose=0, 
+#         cols=None, 
+#         drop_invariant=False, 
+#         return_df=True, 
+#         handle_missing='value',
+#         handle_unknown='value', 
+#         min_samples_leaf=1, 
+#         smoothing=1.0
+#     )
+#     df_encoded = []
+#     df_encoded.append(target.fit_transform(dfs[0]))
+#     for i in dfs[1:]:
+#         df_encoded.append(target.transform(i))

--- a/functions/processing.py
+++ b/functions/processing.py
@@ -59,6 +59,12 @@ async def set_groupby(
     str: JSON
     ```
     """
+    axis       = 0       if axis       == "" else axis
+    as_index   = "True"  if as_index   == "" else as_index
+    sort       = "True"  if sort       == "" else sort
+    group_keys = "True"  if group_keys == "" else group_keys
+    observed   = "False" if observed   == "" else observed
+    dropna     = "True"  if dropna     == "" else dropna
 
     ## func
     func_list = ["sum", "count", "mean", "min", "max", "std", "median", "size"]
@@ -170,6 +176,10 @@ async def set_drop(
     str: JSON
     ```
     """
+
+    axis   = 0       if axis   == "" else axis
+    errors = "raise" if errors == "" else errors
+
     ## errors
     errors = errors.lower()
     if errors not in ["raise", "ignore"]:
@@ -242,6 +252,12 @@ async def set_dropna(
     str: JSON
     ```
     """
+
+    axis   = 0     if axis   == "" else axis
+    how    = 'any' if how    == "" else how
+    thresh = None  if thresh == "" else thresh
+    subset = None  if subset == "" else subset
+
     ## axis
     try:
         axis = int(axis)
@@ -320,6 +336,9 @@ async def set_rename(
     str: JSON
     ```
     """
+    copy   = "true"   if copy   == "" else copy
+    errors = "ignore" if errors == "" else errors
+
     df = pd.read_json(await item.json())
 
     ## keys
@@ -394,6 +413,13 @@ async def set_sort_values(
     str: JSON
     ```
     """
+    axis   = 0           if axis   == "" else axis
+    ascd   = "true"      if ascd   == "" else ascd
+    kind   = "quicksort" if kind   == "" else kind
+    na_pos = "last"      if na_pos == "" else na_pos
+    ig_idx = "false"     if ig_idx == "" else ig_idx
+    key    = None        if key    == "" else key
+
     df = pd.read_json(await item.json())
 
     ## by
@@ -487,6 +513,19 @@ async def set_merge(
     str: JSON
     ```
     """
+    how         = "inner" if how         == "" else how
+    on          = None    if on          == "" else on
+    left_on     = None    if left_on     == "" else left_on
+    right_on    = None    if right_on    == "" else right_on
+    left_index  = "false" if left_index  == "" else left_index
+    right_index = "false" if right_index == "" else right_index
+    sort        = "false" if sort        == "" else sort
+    left_suf    = "_x"    if left_suf    == "" else left_suf
+    right_suf   = "_y"    if right_suf   == "" else right_suf
+    copy        = "true"  if copy        == "" else copy
+    indicator   = "false" if indicator   == "" else indicator
+    validate    = None    if validate    == "" else validate
+
     js = json.loads(await item.json())
     df1 = pd.DataFrame(js["item1"])
     df2 = pd.DataFrame(js["item2"])
@@ -616,6 +655,16 @@ async def set_concat(
     str: JSON
     ```
     """
+    axis       = 0       if axis       == "" else axis
+    join       = "outer" if join       == "" else join
+    ig_idx     = "false" if ig_idx     == "" else ig_idx
+    keys       = None    if keys       == "" else keys
+    # levels     = None    if levels     == "" else levels
+    names      = None    if names      == "" else names
+    veri_integ = "false" if veri_integ == "" else veri_integ
+    sort       = "false" if sort       == "" else sort
+    copy       = "true"  if copy       == "" else copy
+
     js = json.loads(await item.json())
     df1 = pd.DataFrame(js["item1"])
     df2 = pd.DataFrame(js["item2"])
@@ -747,6 +796,12 @@ async def set_column(
     str: JSON
     ```
     """
+    cols     = None if cols     == "" else cols
+    col_from = None if col_from == "" else col_from
+    col_to   = None if col_to   == "" else col_to
+    func     = None if func     == "" else func
+    cols_ops = None if cols_ops == "" else cols_ops
+
     df = pd.read_json(await item.json())
     dfcols = set(df.columns)
     # left: df[col], right: some function

--- a/main.py
+++ b/main.py
@@ -48,7 +48,10 @@ from functions import (
     set_sort_values,
     set_merge,
     set_concat,
-    set_column
+    set_column,
+
+    set_feature_target_split,
+    set_train_test_split,
 )
 
 from visualization import (
@@ -73,9 +76,6 @@ get_col_condition  = app.post("/dataframe/col_condition")  (get_col_condition)
 get_loc            = app.post("/dataframe/loc")            (get_loc)
 get_iloc           = app.post("/dataframe/iloc")           (get_iloc)
 
-
-
-
 set_transpose      = app.post("/dataframe/transpose")      (set_transpose)
 set_groupby        = app.post("/dataframe/groupby")        (set_groupby)
 set_drop           = app.post("/dataframe/drop")           (set_drop)
@@ -86,6 +86,10 @@ set_sort_values    = app.post("/dataframe/sort_values")    (set_sort_values)
 set_merge          = app.post("/dataframe/merge")          (set_merge)
 set_concat         = app.post("/dataframe/concat")         (set_concat)
 set_column         = app.post("/dataframe/set_column")     (set_column)
+
+set_feature_target_split = app.post("/dataframe/feature_target_split")(set_feature_target_split)
+set_train_test_split     = app.post("/dataframe/train_test_split")    (set_train_test_split)
+
 
 
 box_plot = app.get("/plot/boxplot")(box_plot)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 numpy
 modin[all]
 sklearn
+category_encoders
+xgboost
 bokeh
 fastapi
 uvicorn[standard]


### PR DESCRIPTION
※ 상단에 안내드린 값에 맞춰 Pull Request 제목과 우측 Label 등 지정해주세요.  
※ 작성 시 **굵게 표시한 것**과 _기울임_ 한 것은 지우셔도 괜찮습니다.

---
_title: "[FeatureMade] 제목"  
labels: ["분류: 기능 구현"]  
reviewer: 'seahahn'_

**※ 이슈에 명시된 기능 구현 완료한 경우 작성하기**  
**※ 구현한 기능이 명시된 Issue를 꼭! 연결시키기**  
**※ 가능하면 기능 설명을 소스 코드의 해당 부분에 docstring 식으로 붙여두는 것을 추천합니다.**  

### 작성자
이경희

### 1. 기능 설명
피쳐(X), 타겟(y) 분리, train test 분리


### 2. 인풋(매개변수) & 아웃풋(return 값) (optional)
#### 1. feature_target_split
```python
# 타겟과 피쳐를 나누는 함수
target = pandas.DataFrame[cols]               # y
feature = pandas.DataFrame.drop(cols, axis=1) # X
```
Args:
```
item (Request, required): JSON, 입력 데이터 프레임(전처리 끝난 데이터 프레임)
cols (str,     required): 쉼표로 구분된 타겟 컬럼.(1개 이상)
```
Returns:
```
str: JSON, {"X":feature_df, "y":target_df}
```
#### 2. train_test_split
```python
X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(X, y)

# 입력 item은 X 와 y 키에 각각 데이터 프레임이 들어있어야 함.
# test_size와 train_size는 둘 중 하나만 입력 가능.
# stratify는 None 또는 'y'만 가능
```
Args:
```
item         (Request, required): JSON, {"X":X_dataframe, "y":y_dataframe}
*,
test_size    (str,     optional): Default = None,   0~1 사이의 소수. 테스트 셋의 비율
train_size   (str,     optional): Default = None,   0~1 사이의 소수. 트레인 셋의 비율
random_state (str,     optional): Default = None,   아무 정수. 랜덤 시드
shuffle      (str,     optional): Default = "true", 셔플 여부. true 셔플함, false, 셔플 안함
stratify     (str,     optional): Default = None,   타겟을 지정. train, valid split할 때 y를 입력하면 됨.
```
Returns:
```
str: JSON, 
{
    "X_train": X_train.to_json(orient="records"),
    "X_test" : X_test .to_json(orient="records"),
    "y_train": y_train.to_json(orient="records"),
    "y_test" : y_test .to_json(orient="records"),
}
```

### 3. 추가 내용 (optional)

빈 스트링이 들어갈 때 정상적으로 동작하지 않는 문제를 해결했습니다.
closes #62

closes #34 
closes #35 